### PR TITLE
Update README and manifest for fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # BIP39
 
-[![Build Status](https://travis-ci.org/bitcoinjs/bip39.png?branch=master)](https://travis-ci.org/bitcoinjs/bip39)
-[![NPM](https://img.shields.io/npm/v/bip39.svg)](https://www.npmjs.org/package/bip39)
+[![NPM](https://img.shields.io/npm/v/bip39.svg)](https://www.npmjs.org/package/@metamask/bip39)
 
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 
 
 JavaScript implementation of [Bitcoin BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki): Mnemonic code for generating deterministic keys
+
+## MetaMask fork
+
+This is a temporary fork of the `bip39` package created by the MetaMask team. Please do not use this package for other projects, use `bip39` directly instead. We are not interested in maintaining this long-term. We will abandon this as soon as we find a suitable replacement, and will not be accepting community issues or PRs.
 
 ## Reminder for developers
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bip39",
+  "name": "@metamask/bip39",
   "version": "3.0.4",
   "description": "Bitcoin BIP39: Mnemonic code for generating deterministic keys",
   "main": "src/index.js",
@@ -17,17 +17,9 @@
     "unit": "tape test/*.js",
     "update": "node -e \"require('./util/wordlists').update()\""
   },
-  "author": "Wei Lu",
-  "contributors": [
-    {
-      "name": "Daniel Cousens",
-      "email": "email@dcousens.com",
-      "url": "http://dcousens.com"
-    }
-  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/bitcoinjs/bip39.git"
+    "url": "https://github.com/metamask/bip39.git"
   },
   "license": "ISC",
   "files": [


### PR DESCRIPTION
The package has been renamed to `@metamask/bip39` so that we can publish this fork to npm, and the package metadata has been updated.

A notice has been added to the README to dissuade others from using this fork. We should replace this with a better maintained alternative as soon as we can. If we decide to take this on ourselves later, we can remove this notice.