### PR TITLE
Remove non-english wordlists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const createHash = require("create-hash");
 const pbkdf2_1 = require("pbkdf2");
 const randomBytes = require("randombytes");
-const _wordlists_1 = require("./_wordlists");
-let DEFAULT_WORDLIST = _wordlists_1._default;
+const DEFAULT_WORDLIST = require('./wordlists/english.json');
 const INVALID_MNEMONIC = 'Invalid mnemonic';
 const INVALID_ENTROPY = 'Invalid entropy';
 const INVALID_CHECKSUM = 'Invalid mnemonic checksum';
@@ -198,27 +197,3 @@ function validateMnemonic(mnemonic, wordlist) {
     return true;
 }
 exports.validateMnemonic = validateMnemonic;
-function setDefaultWordlist(language) {
-    const result = _wordlists_1.wordlists[language];
-    if (result) {
-        DEFAULT_WORDLIST = result;
-    }
-    else {
-        throw new Error('Could not find wordlist for language "' + language + '"');
-    }
-}
-exports.setDefaultWordlist = setDefaultWordlist;
-function getDefaultWordlist() {
-    if (!DEFAULT_WORDLIST) {
-        throw new Error('No Default Wordlist set');
-    }
-    return Object.keys(_wordlists_1.wordlists).filter((lang) => {
-        if (lang === 'JA' || lang === 'EN') {
-            return false;
-        }
-        return _wordlists_1.wordlists[lang].every((word, index) => word === DEFAULT_WORDLIST[index]);
-    })[0];
-}
-exports.getDefaultWordlist = getDefaultWordlist;
-var _wordlists_2 = require("./_wordlists");
-exports.wordlists = _wordlists_2.wordlists;

--- a/test/index.js
+++ b/test/index.js
@@ -38,15 +38,15 @@ function testVector (description, wordlist, password, v, i) {
 vectors.english.forEach(function(v, i) { testVector('English', undefined, 'TREZOR', v, i) })
 vectors.japanese.forEach(function (v, i) { testVector('Japanese', WORDLISTS.japanese, '㍍ガバヴァぱばぐゞちぢ十人十色', v, i) })
 vectors.custom.forEach(function (v, i) { testVector('Custom', WORDLISTS.custom, undefined, v, i) })
-
-test('getDefaultWordlist returns "english"', function (t) {
+// Test skipped because wordlists other than english have been removed
+test.skip('getDefaultWordlist returns "english"', function (t) {
   t.plan(1)
   const english = bip39.getDefaultWordlist()
   t.equal(english, 'english')
   // TODO: Test that Error throws when called if no wordlists are compiled with bip39
 })
-
-test('setDefaultWordlist changes default wordlist', function (t) {
+// Test skipped because wordlists other than english have been removed
+test.skip('setDefaultWordlist changes default wordlist', function (t) {
   t.plan(4)
   const english = bip39.getDefaultWordlist()
   t.equal(english, 'english')
@@ -64,8 +64,8 @@ test('setDefaultWordlist changes default wordlist', function (t) {
   const phraseEnglish = bip39.entropyToMnemonic('00000000000000000000000000000000').toString();
   t.equal(phraseEnglish.slice(0, 7), 'abandon')
 })
-
-test('setDefaultWordlist throws on unknown wordlist', function (t) {
+// Test skipped because wordlists other than english have been removed
+test.skip('setDefaultWordlist throws on unknown wordlist', function (t) {
   t.plan(2)
   const english = bip39.getDefaultWordlist()
   t.equal(english, 'english')
@@ -135,14 +135,14 @@ test('validateMnemonic', function (t) {
   t.equal(bip39.validateMnemonic('turtle front uncle idea crush write shrug there lottery flower risky shell'), false, 'fails if mnemonic words are not in the word list')
   t.equal(bip39.validateMnemonic('sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten sleep kitten'), false, 'fails for invalid checksum')
 })
-
-test('exposes standard wordlists', function (t) {
+// Test skipped because wordlists other than english have been removed
+test.skip('exposes standard wordlists', function (t) {
   t.plan(2)
   t.same(bip39.wordlists.EN, WORDLISTS.english)
   t.equal(bip39.wordlists.EN.length, 2048)
 })
-
-test('verify wordlists from https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md', function (t) {
+// Test skipped because wordlists other than english have been removed
+test.skip('verify wordlists from https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md', function (t) {
   download().then(function (wordlists) {
     Object.keys(wordlists).forEach(function (name) {
       t.same(bip39.wordlists[name], wordlists[name])

--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -1,9 +1,9 @@
 import * as createHash from 'create-hash';
 import { pbkdf2, pbkdf2Sync } from 'pbkdf2';
 import * as randomBytes from 'randombytes';
-import { _default as _DEFAULT_WORDLIST, wordlists } from './_wordlists';
-
-let DEFAULT_WORDLIST: string[] | undefined = _DEFAULT_WORDLIST;
+const DEFAULT_WORDLIST = require('./wordlists/english.json') as
+  | string[]
+  | undefined;
 
 const INVALID_MNEMONIC = 'Invalid mnemonic';
 const INVALID_ENTROPY = 'Invalid entropy';
@@ -281,31 +281,3 @@ export function validateMnemonic(
 
   return true;
 }
-
-export function setDefaultWordlist(language: string): void {
-  const result = wordlists[language];
-  if (result) {
-    DEFAULT_WORDLIST = result;
-  } else {
-    throw new Error('Could not find wordlist for language "' + language + '"');
-  }
-}
-
-export function getDefaultWordlist(): string {
-  if (!DEFAULT_WORDLIST) {
-    throw new Error('No Default Wordlist set');
-  }
-  return Object.keys(wordlists).filter(
-    (lang: string): boolean => {
-      if (lang === 'JA' || lang === 'EN') {
-        return false;
-      }
-      return wordlists[lang].every(
-        (word: string, index: number): boolean =>
-          word === DEFAULT_WORDLIST![index],
-      );
-    },
-  )[0];
-}
-
-export { wordlists } from './_wordlists';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,6 +5,3 @@ export declare function mnemonicToEntropy(mnemonic: string | Buffer, wordlist?: 
 export declare function entropyToMnemonic(entropy: Buffer | string, wordlist?: string[]): Buffer;
 export declare function generateMnemonic(strength?: number, rng?: (size: number) => Buffer, wordlist?: string[]): Buffer;
 export declare function validateMnemonic(mnemonic: string, wordlist?: string[]): boolean;
-export declare function setDefaultWordlist(language: string): void;
-export declare function getDefaultWordlist(): string;
-export { wordlists } from './_wordlists';


### PR DESCRIPTION
As part of an effort to reduce the bundle size of the extension we are looking to [remove extraneous word-lists from our bundle](https://github.com/metamask/metamask-extension/issues/15022). Currently we do not support SRP generation or recovery with non-english words, and there is no near to medium plan to support non-English SRPs. 

As you can see, currently these unused wordlist json files are increasing our bundle by around 200kb:
![Screen Shot 2022-08-09 at 3 05 23 PM](https://user-images.githubusercontent.com/34557516/183750943-0219cbdc-057b-4db6-b8cd-956f2925a616.png)
